### PR TITLE
Get rid of "System Volume Information" folder in directory-Listing

### DIFF
--- a/Pico_1140_DC/Pico_1140.cxx
+++ b/Pico_1140_DC/Pico_1140.cxx
@@ -41,7 +41,7 @@ void ls(const char *dir) {
 	FILINFO fno; /* File information */
 	memset(&dj, 0, sizeof dj);
 	memset(&fno, 0, sizeof fno);
-	fr = f_findfirst(&dj, &fno, p_dir, "*");
+	fr = f_findfirst(&dj, &fno, p_dir, "*.DSK");
 	if (FR_OK != fr) {
 		printf("f_findfirst error: %s (%d)\n", FRESULT_str(fr), fr);
 		return;


### PR DESCRIPTION
with *.DSK the directory now does only show  .dsk/.DSK files :) (the normally hidden "System Volume Information"-folder is also created by Windows on USB-pen-drives :( )